### PR TITLE
Yh80/iris guide update

### DIFF
--- a/iris-build-guide-archive.md
+++ b/iris-build-guide-archive.md
@@ -1,0 +1,114 @@
+# Iris Build Guide Archive
+
+## Please use the following guide: [Updated build log for Rev. 2.1b/2.4/2.5](https://imgur.com/a/wc0bO)
+
+LED fix for right PCB of Rev. 2.1b or 2.4, in case you soldered the MOSFET to the side with the bad trace: [Rev. 2.1b/2.4 LED Fix](https://imgur.com/a/uqt6T)
+
+##
+
+##
+
+##
+
+## Older Build Log for Rev. 2.0 to 2.1a:
+
+**The guide below is just for reference for those with older PCBs, please see the link above for newer PCBs**
+
+Imgur Album: [Iris Build Log](https://imgur.com/a/iQH2W)
+
+## ![](https://i.imgur.com/uqIwtGy.jpg) {#parts-list}
+
+## Parts List {#parts-list}
+
+Here's a list of parts needed for the build:
+
+* 2 [Iris PCBs](https://keeb.io/products/iris-keyboard-split-ergonomic-keyboard)
+* 54-56 [diodes](https://keeb.io/products/1n4148-diodes) \(through-hole and SMD diodes supported\)
+* 2 [Arduino Pro Micros](https://keeb.io/products/pro-micro-5v-16mhz-arduino-compatible-atmega32u4)
+* 2 push buttons for resetting
+* 54-56 [switches](https://keeb.io/products/gateron-switches) \(MX-compatible and Alps switches are supported\)
+* Case
+* 2 [TRRS jacks](https://keeb.io/products/trrs-jacks-3-5mm-one-pair)
+* 1 [TRRS cable](https://keeb.io/products/trrs-cable)
+* Optional parts
+  * 2 4.7kΩ resistors if doing I2C
+  * 2u PCB mount MX stabilizers if using 2u keys
+  * For LEDs:
+    * Rev. 2.1a and lower:
+      * 2 100Ω resistors \(one used for each half\)
+      * 2 100kΩ resistors \(one used for each half\)
+    * Rev. 2.1b and newer:
+      * 2 4.7kΩ resistors \(one used for each half\)
+    * 2 N-channel MOSFETs
+    * 56 470Ω resistors \(or whatever value is appropriate for the LEDs you are using\)
+
+## Build Steps {#build-steps}
+
+Here's a summary of the build steps:
+
+1. Solder components
+   1. Solder diodes
+   2. Solder push button and TRRS jacks
+   3. Solder I2C resistors \(optional\)
+   4. Solder LED components \(MOSFET and resistors\) \(optional\)
+   5. Solder Pro Micro header pins
+2. Add 2u stabilizers
+3. Solder switches
+4. Solder LEDs
+5. Flash Pro Micros
+6. Solder Pro Micros
+7. Solder RGB strip \(optional\)
+
+## Solder Components
+
+The diodes, resistors, MOSFETs, push buttons, TRRS jacks,, and Pro Micro header pins can be soldered in any order.
+
+### Solder diodes
+
+All the diodes are oriented with the line towards the bottom. All the resistors are oriented horizontally, direction doesn't matter. The PCB supports both SMD and through-hole diodes and resistors, SMD ones are shown here. For through hole diodes, the black line will be at the bottom, towards the square pad.
+
+![](https://i.imgur.com/PS0GEXA.jpg)
+
+Through-hole resistors shown here, note that the black line on the diodes are all facing down at the square pad.![](https://i.imgur.com/j3do2SU.png)
+
+### Solder reset push buttons and TRRS jacks
+
+### ![](https://i.imgur.com/YqDm7vj.jpg)Info about resistors in the kit
+
+The color coded lines on the resistors can be hard to read/decipher, so the paper from the tape reel have been marked with different color lines.
+
+* No Line - 4.7kΩ resistors for I2C \(only used on master half\)
+* Blue Line - 100kΩ resistors for MOSFET \(1 for each half\)
+* Red Line - 100Ω resistors for MOSFET \(1 for each half\)![](https://i.imgur.com/zz1rnXv.png)Some of the PCB kits may have these unlabeled resistors instead of the ones in the previous picture. Here's how to distinguish between them by looking at the bands:![](https://i.imgur.com/HmEYzag.png)
+
+### Solder I2C resistors \(optional\)
+
+The default firmware for the Iris uses serial communication between the two halves using a single pin of the TRRS cable. Serial communication only allow for communication between two parts, which is fine for almost all builds.
+
+However, in the future, there might be additional parts that you can add, like a numpad, OLED screen, etc. To support this, the communication protocol would need to be switched over I2C, which can support multiple devices. To add support for I2C, all you need to do is add the 2 4.7kΩ resistors to one of the halves \(other half does not need them\). Also, it doesn't hurt to add these resistors if using serial communication.
+
+tl;dr: Adding this is optional, but you might as well do it as it's only 2 more components to solder.
+
+Left half shown here:![](https://i.imgur.com/CUjnMP3.png)
+
+Right half, note that the two spot for the 4.7kΩ resistors are left empty:![](https://i.imgur.com/MQFqGEo.jpg)
+
+### Solder LED support components \(optional\)
+
+For each half, add 1 MOSFET, 100Ω resistor, and 100kΩ resistor.![](https://i.imgur.com/2rwjJRf.jpg)
+
+To solder the MOSET on, first add a little bit of solder to one of the pads on the PCB. Then position the MOSFET over the pads and heat up the pad to solder the first leg into place. It helps to use a pair of tweezers to hold the MOSFET and position it while heating up the pad.![](https://i.imgur.com/k3cwV69.png)
+
+Once the first leg of the MOSFET has been positioned properly, solder the other 2 pads.![](https://i.imgur.com/FXKesdZ.png)
+
+Next, add all of the resistors for each switch. 470Ω resistors are commonly used, but this value might vary, based on the LEDs you use and the amount of current they draw.
+
+Solder the resistor in the area of the Pro Micro on the other side \(top side\), so it is out of the way of the Pro Micro when you install it. Alternatively, you can just install all of the resistors on the top side.![](https://i.imgur.com/tazkMue.png)
+
+Lone resistor soldered on the top side.![](https://i.imgur.com/DGoQ3U0.png)
+
+### Solder Pro Micro header pins
+
+### Solder switches
+
+### Solder LEDs

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -158,4 +158,23 @@ Trim down the switch pins, LED pins, and resistor pins that the Pro Micro will s
 
 ## Flash Pro Micros
 
+![](https://i.imgur.com/Ca93q9s.jpg)
+
+The last thing to install is the Pro Micros. Before soldering them to the board, it is highly recommended to flash them first, in case one or both of them are defective.
+
 Refer to the [Flashing Firmware](flashing-firmware.md) Guide for steps on performing a flash to test the Pro Micro controllers.
+
+## Solder Pro Micros
+
+If using a bottom plate that conducts electricity, like a stainless steel or aluminum plate, add Kapton or electric tape on top of the TRRS jack. Also put some down where the Pro Micro will be:
+![](https://i.imgur.com/Qw7qrWA.jpg?1)
+
+Set the Pro Micro through the pins, making sure RAW and TX0 are aligned properly with the markings on the PCB. The orientation on both PCBs is different. (Left half shown here):
+![](https://i.imgur.com/IMDAm28.jpg)
+
+MYTH: Keys will be reversed if the Pro Micro is reversed
+TRUTH: **This is totally not the case, so pay attention!** Soldering the Pro Micro on backwards will short VCC and Reset together, preventing you from flashing. Even if flashed beforehand, it will do nothing meaningful in this orientation.
+
+Right half:![](https://i.imgur.com/2KMFIE4.jpg?1)
+
+Left PCB on the left, right PCB on the right:![](https://i.imgur.com/x950DTT.jpg?1)

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -155,3 +155,7 @@ Install the LEDs. Longer leg is the anode and goes with the circular pad marked 
 I normally pry off the plastic parts of the header pins to made the Pro Micro sit more flush with the PCB. An added benefit of this is that the Micro USB port for the left half is sandwiched between the Iris PCB and the Pro Micro PCB, making it less likely to be ripped off.
 
 Trim down the switch pins, LED pins, and resistor pins that the Pro Micro will sit on top of with a flush cutter:![](https://i.imgur.com/vh0WAXg.jpg)
+
+## Flash Pro Micros
+
+Refer to the [Flashing Firmware](flashing-firmware.md) Guide for steps on performing a flash to test the Pro Micro controllers.

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -1,10 +1,10 @@
-# Iris Build Guide
+# Iris Build Guides
 
 #### Previous Guides/Info
 * LED fix for right PCB of Rev. 2.1b or 2.4, in case you soldered the MOSFET to the side with the bad trace: [Rev. 2.1b/2.4 LED Fix](https://imgur.com/a/uqt6T)
 * Older Build Log for Rev. 2.0 to 2.1a: [Iris Build Guide Archive](iris-build-guide-archive.md)
 
-## Iris 2.1b/2.4/2.5 Build Guide
+# Iris 2.1b/2.4/2.5 Build Guide
 [Imgur Album](https://imgur.com/a/wc0bO)
 
 ## ![](https://i.imgur.com/JMq4iIA.jpg) {#parts-list}
@@ -13,38 +13,26 @@
 
 Here's a list of parts needed for the build:
 
-*All of the parts needed are shown here, except for Pro Micros and TRRS cable*
+*All of the parts needed are shown here, except for Pro Micros, TRRS cable, and switches*
 
 * 2 sets [Top/Bottom plates with M2 screws and standoffs](https://keeb.io/products/iris-keyboard-case-plates)
 * 2 [Iris PCBs](https://keeb.io/products/iris-keyboard-split-ergonomic-keyboard)
 * 2 TRRS jacks
+* 1 [TRRS cable](https://keeb.io/products/trrs-cable)
 * 2 reset switches
 * 4 4.7kΩ resistors
     * 2 used for I2C
     * 1 used for LED support on left half
     * 1 used for LED support on right half)
 * 54-56 1N4148 diodes - through-hole \(shown\) and [SMD diodes](https://keeb.io/products/1n4148-diodes) supported
-* 54-56 470Ω resistors (optional, for LED backlight)
-* 54-56 LEDs (optional, for LED backlight)
-* WS2812B RGB LED Strip (optional, for underglow)
+* 54-56 470Ω resistors \(optional, for LED backlight\)
+* 54-56 LEDs \(optional, for LED backlight\)
+* 2 N-channel MOSFETs \(optional, for LED control\)
+* WS2812B RGB LED Strip \(optional, for underglow\)
 * 2 [Arduino Pro Micros](https://keeb.io/products/pro-micro-5v-16mhz-arduino-compatible-atmega32u4)
-
-*Parts needed, but not shown:*
 * 54-56 switches (MX-compatible and Alps switches are supported)
-
-
-* 1 [TRRS cable](https://keeb.io/products/trrs-cable)
-* Optional parts
-  * 2 4.7kΩ resistors if doing I2C
-  * 2u PCB mount MX stabilizers if using 2u keys
-  * For LEDs:
-    * Rev. 2.1a and lower:
-      * 2 100Ω resistors \(one used for each half\)
-      * 2 100kΩ resistors \(one used for each half\)
-    * Rev. 2.1b and newer:
-      * 2 4.7kΩ resistors \(one used for each half\)
-    * 2 N-channel MOSFETs
-
+* Optional parts \(*not shown*\)
+    * 2u PCB mount MX stabilizers if using 2u keys
 
 ## Build Steps {#build-steps}
 

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -118,7 +118,7 @@ Add 470Ω resistors for LEDs. Resistors don't have polarity, so orientation does
 
 Right PCB:![](https://i.imgur.com/3CJVPlx.jpg)
 
-To add the MOSFET, tin one of the pins on the PCB first. **NOTE: For the 2.1b and 2.4 PCBs, there's a missing trace/via on one of the pads for the MOSFET of the right half (the one shown here). To resolve this, solder the MOSFET to the other side of the board, as the pads for those are fine. (Issue has been fixed on Rev. 2.5 PCB)** If you do happen to solder the MOSFET to this side by accident, you can perform this fix to resolve the issue: https://imgur.com/a/uqt6T :![](https://i.imgur.com/nsehRiB.jpg)
+To add the MOSFET, tin one of the pins on the PCB first. **NOTE: For the 2.1b and 2.4 PCBs, there's a missing trace/via on one of the pads for the MOSFET of the right half (the one shown here). To resolve this, solder the MOSFET to the other side of the board, as the pads for those are fine. (Issue has been fixed on Rev. 2.5 PCB)** If you do happen to solder the MOSFET to this side by accident, you can perform this fix to resolve the issue: https://imgur.com/a/uqt6T @@ :![](https://i.imgur.com/nsehRiB.jpg)
 
 For each half, add 1 MOSFET, 100Ω resistor, and 100kΩ resistor.![](https://i.imgur.com/2rwjJRf.jpg)
 

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -178,3 +178,7 @@ TRUTH: **This is totally not the case, so pay attention!** Soldering the Pro Mic
 Right half:![](https://i.imgur.com/2KMFIE4.jpg?1)
 
 Left PCB on the left, right PCB on the right:![](https://i.imgur.com/x950DTT.jpg?1)
+
+## Solder RGB strip \(optional\)
+
+Refer to the [RGB Underglow](adding-rgb-underglow.md) Guide for steps to install the RGB light strip.

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -79,21 +79,26 @@ The diodes, resistors, MOSFETs, push buttons, TRRS jacks,, and Pro Micro header 
 
 ### Solder diodes
 
-All the diodes are oriented with the line towards the bottom. All the resistors are oriented horizontally, direction doesn't matter. The PCB supports both SMD and through-hole diodes and resistors, SMD ones are shown here. For through hole diodes, the black line will be at the bottom, towards the square pad.
+On the bottom side of the PCB, insert diodes with the black line towards the bottom. Square = Black line. All of the diodes are oriented vertically on the PCB:![](https://i.imgur.com/Pft9ufA.jpg)
 
-![](https://i.imgur.com/PS0GEXA.jpg)
+NOTE for Kailh Low-Profile PCBs (Rev. 2.2-KLP): The diode orientation is flipped to move the LEDs to the north side. The black line will point towards the top on these PCBs.
 
-Through-hole resistors shown here, note that the black line on the diodes are all facing down at the square pad.![](https://i.imgur.com/j3do2SU.png)
+Some people stick the diodes on the top side of the PCB, I don't recommend doing it that way, because you can't replace them once everything is assembled using that method.
+
+Bend the legs out to hold the diodes in place for when you solder them in:![](https://i.imgur.com/TaYV4vF.jpg)
+
+Diode insertion complete:![](https://i.imgur.com/xoO48or.jpg)
+
+Left PCB:![](https://i.imgur.com/O4wuLju.jpg)
+
+Right PCB:![](https://i.imgur.com/ZD4B4PR.jpg)
+
+
 
 ### Solder reset push buttons and TRRS jacks
 
-### ![](https://i.imgur.com/YqDm7vj.jpg)Info about resistors in the kit
+Add the TRRS jacks and reset switches:![](https://i.imgur.com/dFTBf3h.jpg)
 
-The color coded lines on the resistors can be hard to read/decipher, so the paper from the tape reel have been marked with different color lines.
-
-* No Line - 4.7kΩ resistors for I2C \(only used on master half\)
-* Blue Line - 100kΩ resistors for MOSFET \(1 for each half\)
-* Red Line - 100Ω resistors for MOSFET \(1 for each half\)![](https://i.imgur.com/zz1rnXv.png)Some of the PCB kits may have these unlabeled resistors instead of the ones in the previous picture. Here's how to distinguish between them by looking at the bands:![](https://i.imgur.com/HmEYzag.png)
 
 ### Solder I2C resistors \(optional\)
 
@@ -103,11 +108,17 @@ However, in the future, there might be additional parts that you can add, like a
 
 tl;dr: Adding this is optional, but you might as well do it as it's only 2 more components to solder.
 
-Left half shown here:![](https://i.imgur.com/CUjnMP3.png)
-
-Right half, note that the two spot for the 4.7kΩ resistors are left empty:![](https://i.imgur.com/MQFqGEo.jpg)
+Add the 2 4.7kΩ resistors for I2C on only one half (I normally do this on the master/left half). Left half shown here:![](https://i.imgur.com/ncxMpI2.jpg)
 
 ### Solder LED support components \(optional\)
+
+Add a 4.7kΩ resistor for LED support in the R3 slot:![](https://i.imgur.com/Jvg2o4d.jpg)
+
+Add 470Ω resistors for LEDs. Resistors don't have polarity, so orientation doesn't matter. **Note that the resistor that's seated with the Pro Micro has been inserted on the top side of the PCB, which prevents it from touching the Pro Micro.** (This resistor will be relocated out of the way in future versions of the PCB) Left side shown here:![](https://i.imgur.com/SERhlBs.jpg)
+
+Right PCB:![](https://i.imgur.com/3CJVPlx.jpg)
+
+To add the MOSFET, tin one of the pins on the PCB first. **NOTE: For the 2.1b and 2.4 PCBs, there's a missing trace/via on one of the pads for the MOSFET of the right half (the one shown here). To resolve this, solder the MOSFET to the other side of the board, as the pads for those are fine. (Issue has been fixed on Rev. 2.5 PCB)** If you do happen to solder the MOSFET to this side by accident, you can perform this fix to resolve the issue: https://imgur.com/a/uqt6T :![](https://i.imgur.com/nsehRiB.jpg)
 
 For each half, add 1 MOSFET, 100Ω resistor, and 100kΩ resistor.![](https://i.imgur.com/2rwjJRf.jpg)
 

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -38,18 +38,40 @@ Here's a list of parts needed for the build:
 
 Here's a summary of the build steps:
 
-1. Solder components
+1. Prepare components
+2. Solder components
    1. Solder diodes
    2. Solder push button and TRRS jacks
    3. Solder I2C resistors \(optional\)
    4. Solder LED components \(MOSFET and resistors\) \(optional\)
    5. Solder Pro Micro header pins
-2. Add 2u stabilizers
 3. Solder switches
 4. Solder LEDs
 5. Flash Pro Micros
 6. Solder Pro Micros
 7. Solder RGB strip \(optional\)
+
+## Prepare components
+
+![](https://i.imgur.com/rrey3ej.jpg)
+
+Bending the diodes. Here, I'm just bending it around my finger
+
+![](https://i.imgur.com/sKo655O.jpg)
+
+Another way to do it, resistors shown here
+
+![](https://i.imgur.com/2D39Ojx.jpg)
+
+Strip of diodes bent
+
+![](https://i.imgur.com/Ys0X30w.jpg)
+
+Ripping off the paper holding all the resistors together. Grip the diodes tightly so they don't bend as you're ripping the paper off.
+
+![](https://i.imgur.com/4cFrb2D.jpg)
+
+All separated from the paper
 
 ## Solder Components
 

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -1,34 +1,38 @@
 # Iris Build Guide
 
-## Please use the following guide: [Updated build log for Rev. 2.1b/2.4/2.5](https://imgur.com/a/wc0bO)
+#### Previous Guides/Info
+* LED fix for right PCB of Rev. 2.1b or 2.4, in case you soldered the MOSFET to the side with the bad trace: [Rev. 2.1b/2.4 LED Fix](https://imgur.com/a/uqt6T)
+* Older Build Log for Rev. 2.0 to 2.1a: [Iris Build Guide Archive](iris-build-guide-archive.md)
 
-LED fix for right PCB of Rev. 2.1b or 2.4, in case you soldered the MOSFET to the side with the bad trace: [Rev. 2.1b/2.4 LED Fix](https://imgur.com/a/uqt6T)
+## Iris 2.1b/2.4/2.5 Build Guide
+[Imgur Album](https://imgur.com/a/wc0bO)
 
-## 
-
-## 
-
-## 
-
-## Older Build Log for Rev. 2.0 to 2.1a:
-
-**The guide below is just for reference for those with older PCBs, please see the link above for newer PCBs**
-
-Imgur Album: [Iris Build Log](https://imgur.com/a/iQH2W)
-
-## ![](https://i.imgur.com/uqIwtGy.jpg) {#parts-list}
+## ![](https://i.imgur.com/JMq4iIA.jpg) {#parts-list}
 
 ## Parts List {#parts-list}
 
 Here's a list of parts needed for the build:
 
+*All of the parts needed are shown here, except for Pro Micros and TRRS cable*
+
+* 2 sets [Top/Bottom plates with M2 screws and standoffs](https://keeb.io/products/iris-keyboard-case-plates)
 * 2 [Iris PCBs](https://keeb.io/products/iris-keyboard-split-ergonomic-keyboard)
-* 54-56 [diodes](https://keeb.io/products/1n4148-diodes) \(through-hole and SMD diodes supported\)
+* 2 TRRS jacks
+* 2 reset switches
+* 4 4.7kΩ resistors
+    * 2 used for I2C
+    * 1 used for LED support on left half
+    * 1 used for LED support on right half)
+* 54-56 1N4148 diodes - through-hole \(shown\) and [SMD diodes](https://keeb.io/products/1n4148-diodes) supported
+* 54-56 470Ω resistors (optional, for LED backlight)
+* 54-56 LEDs (optional, for LED backlight)
+* WS2812B RGB LED Strip (optional, for underglow)
 * 2 [Arduino Pro Micros](https://keeb.io/products/pro-micro-5v-16mhz-arduino-compatible-atmega32u4)
-* 2 push buttons for resetting
-* 54-56 [switches](https://keeb.io/products/gateron-switches) \(MX-compatible and Alps switches are supported\)
-* Case
-* 2 [TRRS jacks](https://keeb.io/products/trrs-jacks-3-5mm-one-pair)
+
+*Parts needed, but not shown:*
+* 54-56 switches (MX-compatible and Alps switches are supported)
+
+
 * 1 [TRRS cable](https://keeb.io/products/trrs-cable)
 * Optional parts
   * 2 4.7kΩ resistors if doing I2C
@@ -40,7 +44,7 @@ Here's a list of parts needed for the build:
     * Rev. 2.1b and newer:
       * 2 4.7kΩ resistors \(one used for each half\)
     * 2 N-channel MOSFETs
-    * 56 470Ω resistors \(or whatever value is appropriate for the LEDs you are using\)
+
 
 ## Build Steps {#build-steps}
 
@@ -112,6 +116,3 @@ Lone resistor soldered on the top side.![](https://i.imgur.com/DGoQ3U0.png)
 ### Solder switches
 
 ### Solder LEDs
-
-
-

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -115,7 +115,7 @@ Add the 2 4.7kΩ resistors for I2C on only one half (I normally do this on the m
 
 Add a 4.7kΩ resistor for LED support in the R3 slot:![](https://i.imgur.com/Jvg2o4d.jpg)
 
-Add 470Ω resistors for LEDs. Resistors don't have polarity, so orientation doesn't matter. **Note that the resistor that's seated with the Pro Micro has been inserted on the top side of the PCB, which prevents it from touching the Pro Micro.** (This resistor will be relocated out of the way in future versions of the PCB) Left side shown here:![](https://i.imgur.com/SERhlBs.jpg)
+Add 470Ω resistors for LEDs. Resistors don't have polarity, so orientation doesn't matter. **Note that the resistor that's seated with the Pro Micro has been inserted on the top side of the PCB, which prevents it from touching the Pro Micro.** (This resistor will be relocated out of the way in future versions of the PCB). Left side shown here:![](https://i.imgur.com/SERhlBs.jpg)
 
 Right PCB:![](https://i.imgur.com/3CJVPlx.jpg)
 
@@ -142,6 +142,10 @@ Right PCB shown:![](https://i.imgur.com/3WUkRM7.jpg?1)
 
 Add the 2u stabilizer if desired. Do this before installing the switch plate and switches:![](https://i.imgur.com/m0mqljb.jpg)
 
-### Solder switches
+## Solder switches
+
+Add switches. Usually, I add switches to the corners first and then solder them before installing the rest of them:![](https://i.imgur.com/deDoaSq.jpg)
+
+All installed:![](https://i.imgur.com/tztl5XA.jpg)
 
 ### Solder LEDs

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -148,4 +148,10 @@ Add switches. Usually, I add switches to the corners first and then solder them 
 
 All installed:![](https://i.imgur.com/tztl5XA.jpg)
 
-### Solder LEDs
+## Solder LEDs
+
+Install the LEDs. Longer leg is the anode and goes with the circular pad marked with \+. The shorter leg is the cathode and goes with the square pad marked with \-:![](https://i.imgur.com/A10RlbS.jpg)
+
+I normally pry off the plastic parts of the header pins to made the Pro Micro sit more flush with the PCB. An added benefit of this is that the Micro USB port for the left half is sandwiched between the Iris PCB and the Pro Micro PCB, making it less likely to be ripped off.
+
+Trim down the switch pins, LED pins, and resistor pins that the Pro Micro will sit on top of with a flush cutter:![](https://i.imgur.com/vh0WAXg.jpg)

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -132,6 +132,12 @@ Repeat the MOSFET installation process on the other PCB:![](https://i.imgur.com/
 
 ### Solder Pro Micro header pins
 
+Install the header pins for the Pro Micro on the underside of the PCB (left PCB shown). You can use some tape to hold the header pins in place while soldering. Solder one pin on and re-adjust/re-solder as needed before doing the rest of the row:![](https://i.imgur.com/TdZ9a23.jpg?1)
+
+Completed left PCB:![](https://i.imgur.com/ijqRWEo.jpg?1)
+
+Right PCB shown:![](https://i.imgur.com/3WUkRM7.jpg?1)
+
 ## Add 2u stabilizers \(optional\)
 
 Add the 2u stabilizer if desired. Do this before installing the switch plate and switches:![](https://i.imgur.com/m0mqljb.jpg)

--- a/iris-build-guide.md
+++ b/iris-build-guide.md
@@ -45,11 +45,12 @@ Here's a summary of the build steps:
    3. Solder I2C resistors \(optional\)
    4. Solder LED components \(MOSFET and resistors\) \(optional\)
    5. Solder Pro Micro header pins
-3. Solder switches
-4. Solder LEDs
-5. Flash Pro Micros
-6. Solder Pro Micros
-7. Solder RGB strip \(optional\)
+3. Add 2u stabilizers \(optional\)
+4. Solder switches
+5. Solder LEDs \(optional\)
+6. Flash Pro Micros
+7. Solder Pro Micros
+8. Solder RGB strip \(optional\)
 
 ## Prepare components
 
@@ -118,21 +119,22 @@ Add 470Ω resistors for LEDs. Resistors don't have polarity, so orientation does
 
 Right PCB:![](https://i.imgur.com/3CJVPlx.jpg)
 
-To add the MOSFET, tin one of the pins on the PCB first. **NOTE: For the 2.1b and 2.4 PCBs, there's a missing trace/via on one of the pads for the MOSFET of the right half (the one shown here). To resolve this, solder the MOSFET to the other side of the board, as the pads for those are fine. (Issue has been fixed on Rev. 2.5 PCB)** If you do happen to solder the MOSFET to this side by accident, you can perform this fix to resolve the issue: https://imgur.com/a/uqt6T @@ :![](https://i.imgur.com/nsehRiB.jpg)
+**NOTE: For the 2.1b and 2.4 PCBs, there's a missing trace/via on one of the pads for the MOSFET of the right half (the one shown here). To resolve this, solder the MOSFET to the other side of the board, as the pads for those are fine. (Issue has been fixed on Rev. 2.5 PCB)** If you do happen to solder the MOSFET to this side by accident, you can perform this fix to resolve the issue: https://imgur.com/a/uqt6T
 
-For each half, add 1 MOSFET, 100Ω resistor, and 100kΩ resistor.![](https://i.imgur.com/2rwjJRf.jpg)
+To add the MOSFET, tin one of the pins on the PCB first:![](https://i.imgur.com/nsehRiB.jpg)
 
-To solder the MOSET on, first add a little bit of solder to one of the pads on the PCB. Then position the MOSFET over the pads and heat up the pad to solder the first leg into place. It helps to use a pair of tweezers to hold the MOSFET and position it while heating up the pad.![](https://i.imgur.com/k3cwV69.png)
+Hold the MOSFET with a pair of tweezers and align it over the footprint. Then solder the first pin:
+![](https://i.imgur.com/tNMOzPH.jpg?1)
 
-Once the first leg of the MOSFET has been positioned properly, solder the other 2 pads.![](https://i.imgur.com/FXKesdZ.png)
+Once you're satisfied with the alignment, solder the other 2 pins:![](https://i.imgur.com/Zm2iJfF.jpg?1)
 
-Next, add all of the resistors for each switch. 470Ω resistors are commonly used, but this value might vary, based on the LEDs you use and the amount of current they draw.
-
-Solder the resistor in the area of the Pro Micro on the other side \(top side\), so it is out of the way of the Pro Micro when you install it. Alternatively, you can just install all of the resistors on the top side.![](https://i.imgur.com/tazkMue.png)
-
-Lone resistor soldered on the top side.![](https://i.imgur.com/DGoQ3U0.png)
+Repeat the MOSFET installation process on the other PCB:![](https://i.imgur.com/e4EfGla.jpg?1)
 
 ### Solder Pro Micro header pins
+
+## Add 2u stabilizers \(optional\)
+
+Add the 2u stabilizer if desired. Do this before installing the switch plate and switches:![](https://i.imgur.com/m0mqljb.jpg)
 
 ### Solder switches
 


### PR DESCRIPTION
Updated the build guide with info and images from Imgur build log and added links to the Archive file, the flashing firmware, and the RGB underglow.

Still new to the github thing. Hopefully, I'm doing all this mostly correct.