### PR TITLE
BDN9 Build Guide: Fix link to adding-rgb-underglow

### DIFF
--- a/docs/bdn9-build-guide.md
+++ b/docs/bdn9-build-guide.md
@@ -151,7 +151,7 @@ Solder the pins and clips the legs off.
 
 ### Add RGB LED Strip \(optional\)
 
-If using an RGB LED strip, see the [Adding RGB Underglow](adding-rgb-underglow) guide.
+If using an RGB LED strip, see the [Adding RGB Underglow](/adding-rgb-underglow) guide.
 
 ### Add individual RGB LEDs \(optional\)
 


### PR DESCRIPTION
Current link leads to https://docs.keeb.io/bdn9-build-guide/adding-rgb-underglow which is 404.

The correct link is https://docs.keeb.io/adding-rgb-underglow/ .

Note: I have not tested the new link. Maybe using `../` is more correct?