### PR TITLE
Update bdn9-build-guide.md

### DIFF
--- a/docs/bdn9-build-guide.md
+++ b/docs/bdn9-build-guide.md
@@ -101,6 +101,9 @@ Insert the rotary encoders from the top-side of the PCB.
 
 Solder them in. Soldering in the side-clips of the encoders is optional, but recommended.
 
+!!! warning "If using Choc low-profile switches, double check/add Kapton tape to solder/metal connections on top of the PCB"
+   When using Choc low-profile switches, there is very little clearance between the switch plate and the top of the PCB. Any exposed metal/solder can cause a short if it touches the switch plate, so before you solder the add switches to the plate, it's advised that you double check that all solder joints on the top of the PCB are cut flush. Alternatively, you can add Kapton tape to any that are raised. It doesn't hurt to add Kapton tape to the encoder legs as well.  
+
 ## Solder Switches
 
 ![](assets/images/bdn9/cKMXmXM.jpeg)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Various keyboards and parts are offered for sale at [Keebio](https://keeb.io). H
 * [Chocopad](chocopad-build-guide.md)
 * [Laplace](laplace-build-log.md)
 * [Quefrency](quefrency-build-guide.md)
+* [BDN9](bdn9-build-guide.md)
 
 ## Contributing
 


### PR DESCRIPTION
I built a BDN9 the other day with choc switches and there as at least one short between the PCB and the plate. My solder joints weren't as flush as they could be, and I was using peel-away sockets, so I just put Kapton tape over everything and it worked fine.