### PR TITLE
Fix indentation of inner lists on index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,16 +5,16 @@
 Various keyboards and parts are offered for sale at [Keebio](https://keeb.io). Here's a brief description of each of them:
 
 * Ortholinear keyboards - Keys laid out in a grid
-  * [Nyquist](nyquist-info.md) - 60% split ortholinear board with keys laid out in a 5x6 grid on each half
-  * Levinson - 40% split ortholinear board with keys laid out in a 4x6 grid on each half
-    * Identical to a Let's Split, but with 2u thumb key support and LED backlight support
-  * Viterbi - 65% split ortholinear board with keys laid out in a 5x7 grid on each half
+    * [Nyquist](nyquist-info.md) - 60% split ortholinear board with keys laid out in a 5x6 grid on each half
+    * Levinson - 40% split ortholinear board with keys laid out in a 4x6 grid on each half
+        * Identical to a Let's Split, but with 2u thumb key support and LED backlight support
+    * Viterbi - 65% split ortholinear board with keys laid out in a 5x7 grid on each half
 * Ergo/Columnar Stagger - Keys laid out with a columnar/vertical stagger to match finger lengths
-  * Iris - 50% split ergonomic board with keys laid out in a 4x6 vertical stagger and 3-4 thumb keys on each half
+    * Iris - 50% split ergonomic board with keys laid out in a 4x6 vertical stagger and 3-4 thumb keys on each half
 * Traditional/horizontal Stagger
-  * Fourier - 40% split staggered keyboard \(13u wide\)
-  * Laplace - 40% staggered keyboard \(13u wide\) - non-split version of Fourier
-  * Quefrency - 60% split staggered keyboard
+    * Fourier - 40% split staggered keyboard \(13u wide\)
+    * Laplace - 40% staggered keyboard \(13u wide\) - non-split version of Fourier
+    * Quefrency - 60% split staggered keyboard
 
 ## Build Guides
 


### PR DESCRIPTION
The indentation of the 2nd level lists was not enough for the Markdown processor to realize they were not top-level items.

This is literally just a whitespace change.