### PR TITLE
docs: [elite-pi] correct qmk compile command

### DIFF
--- a/docs/elite-pi-guide.md
+++ b/docs/elite-pi-guide.md
@@ -46,7 +46,7 @@ To use the converter, see the instructions here: [QMK converter usage](https://d
 
 Using QMK CLI:
 ```js
-qmk flash -c -kb keebio/levinson/rev3 -km default -e CONVERT_TO=elite_pi
+qmk compile -c -kb keebio/levinson/rev3 -km default -e CONVERT_TO=elite_pi
 ```
 
 Using `make`:


### PR DESCRIPTION
I believe you want `compile` and not `flash` as the flashing will be done by just copying the output uf2 file.

This has tripped people up in the past:
- <https://www.reddit.com/r/olkb/comments/1054dtb/compiling_for_elite_pi/>
- <https://www.reddit.com/r/ErgoMechKeyboards/comments/12ru3eb/help_sofle_v1_elite_pi/>